### PR TITLE
feat: Added hot swaps

### DIFF
--- a/files.go
+++ b/files.go
@@ -213,3 +213,146 @@ func ListFiles(amount string, pageToken string, cidPending bool, name string, ci
 	return response, nil
 
 }
+
+func GetSwapHistory(cid string, domain string) (GetSwapHistoryResponse, error) {
+	jwt, err := findToken()
+	if err != nil {
+		return GetSwapHistoryResponse{}, err
+	}
+	url := fmt.Sprintf("https://api.pinata.cloud/v3/files/swap/%s?", cid)
+
+	params := []string{}
+
+	if domain != "" {
+		params = append(params, "domain="+domain)
+	} else {
+		internalDomain, err := findGatewayDomain()
+		if err != nil {
+			return GetSwapHistoryResponse{}, err
+		}
+		params = append(params, "domain="+string(internalDomain))
+	}
+	if len(params) > 0 {
+		url += strings.Join(params, "&")
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+
+	if err != nil {
+		return GetSwapHistoryResponse{}, errors.Join(err, errors.New("failed to create the request"))
+	}
+	req.Header.Set("Authorization", "Bearer "+string(jwt))
+	req.Header.Set("content-type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return GetSwapHistoryResponse{}, errors.Join(err, errors.New("failed to send the request"))
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return GetSwapHistoryResponse{}, fmt.Errorf("server Returned an error %d", resp.StatusCode)
+	}
+
+	var response GetSwapHistoryResponse
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		return GetSwapHistoryResponse{}, err
+	}
+	formattedJSON, err := json.MarshalIndent(response.Data, "", "    ")
+	if err != nil {
+		return GetSwapHistoryResponse{}, errors.New("failed to format JSON")
+	}
+
+	fmt.Println(string(formattedJSON))
+
+	return response, nil
+
+}
+
+func AddSwap(cid string, swapCid string) (AddSwapResponse, error) {
+	jwt, err := findToken()
+	if err != nil {
+		return AddSwapResponse{}, err
+	}
+	url := fmt.Sprintf("https://api.pinata.cloud/v3/files/swap/%s", cid)
+
+	payload := AddSwapBody{
+		SwapCid: swapCid,
+	}
+
+	jsonPayload, err := json.Marshal(payload)
+
+	if err != nil {
+		return AddSwapResponse{}, errors.Join(err, errors.New("Failed to marshal paylod"))
+	}
+
+	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(jsonPayload))
+
+	if err != nil {
+		return AddSwapResponse{}, errors.Join(err, errors.New("failed to create the request"))
+	}
+	req.Header.Set("Authorization", "Bearer "+string(jwt))
+	req.Header.Set("content-type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return AddSwapResponse{}, errors.Join(err, errors.New("failed to send the request"))
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return AddSwapResponse{}, fmt.Errorf("server Returned an error %d", resp.StatusCode)
+	}
+
+	var response AddSwapResponse
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		return AddSwapResponse{}, err
+	}
+	formattedJSON, err := json.MarshalIndent(response.Data, "", "    ")
+	if err != nil {
+		return AddSwapResponse{}, errors.New("failed to format JSON")
+	}
+
+	fmt.Println(string(formattedJSON))
+
+	return response, nil
+
+}
+
+func RemoveSwap(cid string) error {
+	jwt, err := findToken()
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("https://api.pinata.cloud/v3/files/swap/%s", cid)
+
+	req, err := http.NewRequest("DELETE", url, nil)
+
+	if err != nil {
+		return errors.Join(err, errors.New("failed to create the request"))
+	}
+	req.Header.Set("Authorization", "Bearer "+string(jwt))
+	req.Header.Set("content-type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return errors.Join(err, errors.New("failed to send the request"))
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("server Returned an error %d", resp.StatusCode)
+	}
+
+	fmt.Println("Swap deleted")
+
+	return nil
+
+}

--- a/main.go
+++ b/main.go
@@ -304,6 +304,48 @@ func main() {
 				},
 			},
 			{
+				Name:    "swaps",
+				Aliases: []string{"s"},
+				Usage:   "Interact and manage hot swaps on Pinata",
+				Subcommands: []*cli.Command{
+					{
+						Name:      "list",
+						Aliases:   []string{"l"},
+						Usage:     "List swaps for a given gateway domain or for your config gateway domain",
+						ArgsUsage: "[cid] [optional gateway domain]",
+						Action: func(ctx *cli.Context) error {
+							cid := ctx.Args().First()
+							domain := ctx.Args().Get(1)
+							_, err := GetSwapHistory(cid, domain)
+							return err
+						},
+					},
+					{
+						Name:      "add",
+						Aliases:   []string{"a"},
+						Usage:     "Add a swap for a CID",
+						ArgsUsage: "[cid] [swap cid]",
+						Action: func(ctx *cli.Context) error {
+							cid := ctx.Args().First()
+							swapCid := ctx.Args().Get(1)
+							_, err := AddSwap(cid, swapCid)
+							return err
+						},
+					},
+					{
+						Name:      "delete",
+						Aliases:   []string{"d"},
+						Usage:     "Remeove a swap for a CID",
+						ArgsUsage: "[cid]",
+						Action: func(ctx *cli.Context) error {
+							cid := ctx.Args().First()
+							err := RemoveSwap(cid)
+							return err
+						},
+					},
+				},
+			},
+			{
 				Name:    "gateways",
 				Aliases: []string{"gw"},
 				Usage:   "Interact with your gateways on Pinata",

--- a/types.go
+++ b/types.go
@@ -97,3 +97,21 @@ type GetGatewaysResponse struct {
 		Rows []GetGatewayItem
 	} `json:"data"`
 }
+
+type GetSwapHistoryResponse struct {
+	Data []struct {
+		MappedCid string `json:"mapped_cid"`
+		CreatedAt string `json:"created_at"`
+	} `json:"data"`
+}
+
+type AddSwapBody struct {
+	SwapCid string `json:"swap_cid"`
+}
+
+type AddSwapResponse struct {
+	Data struct {
+		MappedCid string `json:"mapped_cid"`
+		CreatedAt string `json:"created_at"`
+	} `json:"data"`
+}


### PR DESCRIPTION
Adds the following command set to the Files CLI to manage hot swaps

```
NAME:
   pinata swaps - Interact and manage hot swaps on Pinata

USAGE:
   pinata swaps command [command options] [arguments...]

COMMANDS:
   list, l    List swaps for a given gateway domain or for your config gateway domain
   add, a     Add a swap for a CID
   delete, d  Remeove a swap for a CID
   help, h    Shows a list of commands or help for one command

OPTIONS:
   --help, -h  show help
```