### PR TITLE
feat: Added group add/remove for files

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -250,3 +250,65 @@ func DeleteGroup(id string) error {
 	return nil
 
 }
+
+func AddFile(groupId string, fileId string) error {
+
+	jwt, err := findToken()
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("https://api.pinata.cloud/v3/files/groups/%s/ids/%s", groupId, fileId)
+
+	req, err := http.NewRequest("PUT", url, nil)
+	if err != nil {
+		return errors.Join(err, errors.New("failed to create the request"))
+	}
+	req.Header.Set("Authorization", "Bearer "+string(jwt))
+	req.Header.Set("content-type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return errors.Join(err, errors.New("failed to send the request"))
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("server Returned an error %d, check CID", resp.StatusCode)
+	}
+
+	fmt.Println("File added to group")
+
+	return nil
+}
+
+func RemoveFile(groupId string, fileId string) error {
+
+	jwt, err := findToken()
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("https://api.pinata.cloud/v3/files/groups/%s/ids/%s", groupId, fileId)
+
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return errors.Join(err, errors.New("failed to create the request"))
+	}
+	req.Header.Set("Authorization", "Bearer "+string(jwt))
+	req.Header.Set("content-type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return errors.Join(err, errors.New("failed to send the request"))
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("server Returned an error %d, check CID", resp.StatusCode)
+	}
+
+	fmt.Println("File removed from group")
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -178,6 +178,42 @@ func main() {
 							return err
 						},
 					},
+					{
+						Name:      "add",
+						Aliases:   []string{"a"},
+						Usage:     "Add a file to a group",
+						ArgsUsage: "[group id] [file id]",
+						Action: func(ctx *cli.Context) error {
+							groupId := ctx.Args().First()
+							fileId := ctx.Args().Get(1)
+							if groupId == "" {
+								return errors.New("no group id provided")
+							}
+							if fileId == "" {
+								return errors.New("no file id provided")
+							}
+							err := AddFile(groupId, fileId)
+							return err
+						},
+					},
+					{
+						Name:      "remove",
+						Aliases:   []string{"r"},
+						Usage:     "Remove a file from a group",
+						ArgsUsage: "[group id] [file id]",
+						Action: func(ctx *cli.Context) error {
+							groupId := ctx.Args().First()
+							fileId := ctx.Args().Get(1)
+							if groupId == "" {
+								return errors.New("no group id provided")
+							}
+							if fileId == "" {
+								return errors.New("no file id provided")
+							}
+							err := RemoveFile(groupId, fileId)
+							return err
+						},
+					},
 				},
 			},
 			{


### PR DESCRIPTION
Added the ability to either add or remove files from a group

```
NAME:
   pinata groups - Interact with file groups

USAGE:
   pinata groups command [command options] [arguments...]

COMMANDS:
   create, c  Create a new group
   list, l    List groups on your account
   update, u  Update a group
   delete, d  Delete a group by ID
   get, g     Get group info by ID
   add, a     Add a file to a group
   remove, r  Remove a file from a group
   help, h    Shows a list of commands or help for one command

OPTIONS:
   --help, -h  show help
```